### PR TITLE
Convert raw pointer to unique pointer to prevent seg fault

### DIFF
--- a/include/motor.h
+++ b/include/motor.h
@@ -4,6 +4,8 @@
 #include <fcntl.h>
 #include <unistd.h>
 #include <iostream>
+#include <memory>
+#include <utility>
 
 #include <libgen.h>
 #include <libudev.h>
@@ -210,11 +212,11 @@ class Motor {
         return s.substr(0,pos);
     }
     // note will probably not be the final interface
-    TextAPIItem operator[](const std::string s) { TextAPIItem t(motor_txt_, s); return t; }
+    TextAPIItem operator[](const std::string s) { TextAPIItem t(motor_txt_.get(), s); return t; }
     int fd() const { return fd_; }
     const Status * status() const { return &status_; }
     Command * command() { return &command_; }
-    TextFile* motor_text() { return motor_txt_; }
+    TextFile* motor_text() { return motor_txt_.get(); }
  protected:
     int open() { fd_ = ::open(dev_path_.c_str(), O_RDWR); fd_flags_ = fcntl(fd_, F_GETFL); return fd_; }
     int close() { return ::close(fd_); }
@@ -223,14 +225,13 @@ class Motor {
     std::string serial_number_, name_, dev_path_, base_path_, version_;
     Status status_ = {};
     Command command_ = {};
-    TextFile *motor_txt_;
+    std::unique_ptr<TextFile> motor_txt_;
 };
 
 class SimulatedMotor : public Motor {
  public:
    SimulatedMotor(std::string name) { 
-       name_ = name; 
-       motor_txt_ =  new TextFile();
+       name_ = name;
        fd_ = ::open("/dev/zero", O_RDONLY); // so that poll can see something
     }
    virtual ~SimulatedMotor() override;
@@ -323,7 +324,7 @@ class UserSpaceMotor : public Motor {
         udev_device_unref(dev);
         udev_unref(udev);  
         open();
-        motor_txt_ = new USBFile(fd_, 1);
+        motor_txt_ = std::make_unique<USBFile>(fd_, 1);
     }
     virtual ~UserSpaceMotor() override;
     virtual ssize_t read() override {

--- a/include/motor.h
+++ b/include/motor.h
@@ -323,7 +323,7 @@ class UserSpaceMotor : public Motor {
         udev_device_unref(dev);
         udev_unref(udev);  
         open();
-        motor_txt_ = std::move(std::unique_ptr<USBFile>(fd_, 1));
+        motor_txt_ = std::move(std::unique_ptr<USBFile>(new USBFile(fd_, 1)));
     }
     virtual ~UserSpaceMotor() override;
     virtual ssize_t read() override {

--- a/include/motor.h
+++ b/include/motor.h
@@ -5,7 +5,6 @@
 #include <unistd.h>
 #include <iostream>
 #include <memory>
-#include <utility>
 
 #include <libgen.h>
 #include <libudev.h>
@@ -324,7 +323,7 @@ class UserSpaceMotor : public Motor {
         udev_device_unref(dev);
         udev_unref(udev);  
         open();
-        motor_txt_ = std::make_unique<USBFile>(fd_, 1);
+        motor_txt_ = std::move(std::unique_ptr<USBFILE>(fd_, 1));
     }
     virtual ~UserSpaceMotor() override;
     virtual ssize_t read() override {

--- a/include/motor.h
+++ b/include/motor.h
@@ -323,7 +323,7 @@ class UserSpaceMotor : public Motor {
         udev_device_unref(dev);
         udev_unref(udev);  
         open();
-        motor_txt_ = std::move(std::unique_ptr<USBFILE>(fd_, 1));
+        motor_txt_ = std::move(std::unique_ptr<USBFile>(fd_, 1));
     }
     virtual ~UserSpaceMotor() override;
     virtual ssize_t read() override {

--- a/src/motor/motor.cpp
+++ b/src/motor/motor.cpp
@@ -18,7 +18,7 @@ Motor::Motor(std::string dev_path) {
     name_ = udev_device_check_and_get_sysattr_value(dev, "device/interface");
 
     std::string text_api_path = udev_device_get_syspath(dev);
-    motor_txt_ = std::move(std::unique_ptr<SysFsFile>(text_api_path + "/device/text_api"));
+    motor_txt_ = std::move(std::unique_ptr<SysFsFile>(new SysFsFile(text_api_path + "/device/text_api")));
 
     struct udev_device *dev_parent = udev_device_get_parent_with_subsystem_devtype(
             dev,

--- a/src/motor/motor.cpp
+++ b/src/motor/motor.cpp
@@ -18,7 +18,7 @@ Motor::Motor(std::string dev_path) {
     name_ = udev_device_check_and_get_sysattr_value(dev, "device/interface");
 
     std::string text_api_path = udev_device_get_syspath(dev);
-    motor_txt_ = std::move(std::unique_ptr<SysFsFile>(new SysFsFile(text_api_path + "/device/text_api")));
+    motor_txt_ = std::move(std::unique_ptr<SysfsFile>(new SysfsFile(text_api_path + "/device/text_api")));
 
     struct udev_device *dev_parent = udev_device_get_parent_with_subsystem_devtype(
             dev,

--- a/src/motor/motor.cpp
+++ b/src/motor/motor.cpp
@@ -18,7 +18,7 @@ Motor::Motor(std::string dev_path) {
     name_ = udev_device_check_and_get_sysattr_value(dev, "device/interface");
 
     std::string text_api_path = udev_device_get_syspath(dev);
-    motor_txt_ = std::make_unique<SysfsFile>(text_api_path + "/device/text_api");
+    motor_txt_ = std::move(std::unique_ptr<SysFsFile>(text_api_path + "/device/text_api"));
 
     struct udev_device *dev_parent = udev_device_get_parent_with_subsystem_devtype(
             dev,

--- a/src/motor/motor.cpp
+++ b/src/motor/motor.cpp
@@ -18,7 +18,7 @@ Motor::Motor(std::string dev_path) {
     name_ = udev_device_check_and_get_sysattr_value(dev, "device/interface");
 
     std::string text_api_path = udev_device_get_syspath(dev);
-    motor_txt_ = new SysfsFile(text_api_path + "/device/text_api");
+    motor_txt_ = std::make_unique<SysfsFile>(text_api_path + "/device/text_api");
 
     struct udev_device *dev_parent = udev_device_get_parent_with_subsystem_devtype(
             dev,
@@ -33,7 +33,7 @@ Motor::Motor(std::string dev_path) {
     open();
 }
 
-Motor::~Motor() { close(); delete motor_txt_; }
+Motor::~Motor() { close(); }
 
 TextFile::~TextFile() {}
 


### PR DESCRIPTION
`get_connected_motors` was seg faulting. Removing manual memory management on the Motor.motor_txt_ member should fix this seg fault.

Relevant call stack:
```#0  0x0000fffff781ee94 in Motor::~Motor (this=0xaaaaaae69780) at /tmp/motor-realtime/src/motor/motor.cpp:36
#1  0x0000fffff7819260 in UserSpaceMotor::UserSpaceMotor (dev_path="/dev/bus/usb/001/007", ep_num=2 '\002', this=<optimized out>)
    at /tmp/motor-realtime/include/motor.h:327
#2  __gnu_cxx::new_allocator<UserSpaceMotor>::construct<UserSpaceMotor, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&> (__p=0xaaaaaae69780, __args="/dev/bus/usb/001/007", this=<optimized out>)
    at /usr/bin/../lib/gcc/aarch64-linux-gnu/11/../../../../include/c++/11/ext/new_allocator.h:162
#3  std::allocator_traits<std::allocator<UserSpaceMotor> >::construct<UserSpaceMotor, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&> (__p=0xaaaaaae69780, __args="/dev/bus/usb/001/007", __a=...)
    at /usr/bin/../lib/gcc/aarch64-linux-gnu/11/../../../../include/c++/11/bits/alloc_traits.h:516
#4  std::_Sp_counted_ptr_inplace<UserSpaceMotor, std::allocator<UserSpaceMotor>, (__gnu_cxx::_Lock_policy)2>::_Sp_counted_ptr_inplace<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&> (this=0xaaaaaae69770, __args="/dev/bus/usb/001/007", __a=...)
    at /usr/bin/../lib/gcc/aarch64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:519
#5  std::__shared_count<(__gnu_cxx::_Lock_policy)2>::__shared_count<UserSpaceMotor, std::allocator<UserSpaceMotor>, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&> (this=0xffffffffed70, __p=@0xffffffffed68: 0x0, __args="/dev/bus/usb/001/007", __a=...)
    at /usr/bin/../lib/gcc/aarch64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:651
#6  std::__shared_ptr<UserSpaceMotor, (__gnu_cxx::_Lock_policy)2>::__shared_ptr<std::allocator<UserSpaceMotor>, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&> (this=0xffffffffed68, __args="/dev/bus/usb/001/007", __tag=...)
    at /usr/bin/../lib/gcc/aarch64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:1342
#7  std::shared_ptr<UserSpaceMotor>::shared_ptr<std::allocator<UserSpaceMotor>, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&> (this=0xffffffffed68, __args="/dev/bus/usb/001/007", __tag=...)
    at /usr/bin/../lib/gcc/aarch64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr.h:409
#8  std::allocate_shared<UserSpaceMotor, std::allocator<UserSpaceMotor>, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&> (__args="/dev/bus/usb/001/007", __a=...) at /usr/bin/../lib/gcc/aarch64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr.h:862
#9  std::make_shared<UserSpaceMotor, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&> (
    __args="/dev/bus/usb/001/007") at /usr/bin/../lib/gcc/aarch64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr.h:878
#10 MotorManager::get_connected_motors (this=0xaaaaaad28cf0, connect=true) at /tmp/motor-realtime/src/motor/motor_manager.cpp:71