### PR TITLE
Remove dynamic memory allocation from poll()

### DIFF
--- a/include/motor_manager.h
+++ b/include/motor_manager.h
@@ -52,7 +52,7 @@ class MotorManager {
     void write_saved_commands();
     void aread();
     void start_nonblocking_read();
-    int poll();
+    int poll(uint32_t timeout_ms = 1);
     int multipoll(uint32_t timeout_ns = 0);
 
     void set_auto_count(bool on=true) { auto_count_ = on; }

--- a/include/motor_manager.h
+++ b/include/motor_manager.h
@@ -44,7 +44,7 @@ class MotorManager {
     std::vector<std::shared_ptr<Motor>> get_motors_by_path(std::vector<std::string> paths, bool connect = true, bool allow_simulated = false);
     std::vector<std::shared_ptr<Motor>> get_motors_by_devpath(std::vector<std::string> devpaths, bool connect = true, bool allow_simulated = false);
     std::vector<std::shared_ptr<Motor>> motors() const { return motors_; }
-    void set_motors(std::vector<std::shared_ptr<Motor>> motors) { motors_ = motors; commands_.resize(motors_.size()); statuses_.resize(motors_.size()); }
+    void set_motors(std::vector<std::shared_ptr<Motor>> motors) { motors_ = motors; commands_.resize(motors_.size()); statuses_.resize(motors_.size()); pollfds_.resize(m.size()); read_error_count_.resize(m.size(), 0);}
     std::vector<Command> &commands() { return commands_; }
     std::vector<Status> &read();
     void write(std::vector<Command> &);
@@ -91,6 +91,7 @@ class MotorManager {
     bool auto_count_ = false;
     bool reconnect_ = false;
     FrequencyLimiter reconnect_rate_ = std::chrono::milliseconds(100);
+    std::vector<pollfd> pollfds_;
 };
 
 inline std::vector<float> get_joint_position(std::vector<Status> statuses) {

--- a/include/motor_manager.h
+++ b/include/motor_manager.h
@@ -45,7 +45,7 @@ class MotorManager {
     std::vector<std::shared_ptr<Motor>> get_motors_by_path(std::vector<std::string> paths, bool connect = true, bool allow_simulated = false);
     std::vector<std::shared_ptr<Motor>> get_motors_by_devpath(std::vector<std::string> devpaths, bool connect = true, bool allow_simulated = false);
     std::vector<std::shared_ptr<Motor>> motors() const { return motors_; }
-    void set_motors(std::vector<std::shared_ptr<Motor>> motors) { motors_ = motors; commands_.resize(motors_.size()); statuses_.resize(motors_.size()); pollfds_.resize(m.size()); read_error_count_.resize(m.size(), 0);}
+    void set_motors(std::vector<std::shared_ptr<Motor>> motors);
     std::vector<Command> &commands() { return commands_; }
     std::vector<Status> &read();
     void write(std::vector<Command> &);

--- a/include/motor_manager.h
+++ b/include/motor_manager.h
@@ -8,6 +8,7 @@
 #include <iomanip>
 #include <chrono>
 #include <map>
+#include <poll.h>
 
 #include "motor.h"
 

--- a/src/motor/motor_manager.cpp
+++ b/src/motor/motor_manager.cpp
@@ -80,11 +80,7 @@ std::vector<std::shared_ptr<Motor>> MotorManager::get_connected_motors(bool conn
         }
     }
     if (connect) {
-        motors_ = m;
-        commands_.resize(m.size());
-        statuses_.resize(m.size());
-        pollfds_.resize(m.size());
-        read_error_count_.resize(m.size(), 0);
+        set_motors(m);
     }
     return m;
 }
@@ -110,11 +106,7 @@ std::vector<std::shared_ptr<Motor>> MotorManager::get_motors_by_name_function(st
         }
     }
     if (connect) {
-        motors_ = m;
-        commands_.resize(m.size());
-        statuses_.resize(m.size());
-        pollfds_.resize(m.size());
-        read_error_count_.resize(m.size(), 0);
+        set_motors(m);
     }
     return m;
 }

--- a/src/motor/motor_manager.cpp
+++ b/src/motor/motor_manager.cpp
@@ -127,16 +127,16 @@ std::vector<std::shared_ptr<Motor>> MotorManager::get_motors_by_devpath(std::vec
     return get_motors_by_name_function(devpaths, &Motor::dev_path, connect, allow_simulated);
 }
 
-void set_motors(std::vector<std::shared_ptr<Motor>> motors) {
+void MotorManager::set_motors(std::vector<std::shared_ptr<Motor>> motors) {
     motors_ = motors;
     commands_.resize(motors_.size());
     statuses_.resize(motors_.size());
-    pollfds_.resize(m.size());
+    pollfds_.resize(motors_.size());
     for (uint8_t i=0; i<pollfds_.size(); i++) {
         pollfds_[i].fd = motors_.at(i)->fd();
         pollfds_[i].events = POLLIN;
     }
-    read_error_count_.resize(m.size(), 0);
+    read_error_count_.resize(motors_.size(), 0);
 }
 
 void MotorManager::start_nonblocking_read() {

--- a/src/motor/motor_manager.cpp
+++ b/src/motor/motor_manager.cpp
@@ -127,6 +127,18 @@ std::vector<std::shared_ptr<Motor>> MotorManager::get_motors_by_devpath(std::vec
     return get_motors_by_name_function(devpaths, &Motor::dev_path, connect, allow_simulated);
 }
 
+void set_motors(std::vector<std::shared_ptr<Motor>> motors) {
+    motors_ = motors;
+    commands_.resize(motors_.size());
+    statuses_.resize(motors_.size());
+    pollfds_.resize(m.size());
+    for (uint8_t i=0; i<pollfds_.size(); i++) {
+        pollfds_[i].fd = motors_.at(i)->fd();
+        pollfds_[i].events = POLLIN;
+    }
+    read_error_count_.resize(m.size(), 0);
+}
+
 void MotorManager::start_nonblocking_read() {
     for (uint8_t i=0; i<motors_.size(); i++) {
         if (motors_[i]->is_nonblocking()) {
@@ -329,11 +341,7 @@ bool MotorManager::deserialize_saved_commands(char *data) {
 }
 
 int MotorManager::poll() {
-    for (uint8_t i=0; i<motors_.size(); i++) {
-        pollfds_.at(i).fd = motors_[i]->fd();
-        pollfds_.at(i).events = POLLIN;
-    }
-    int retval = ::poll(pollfds_.data(), motors_.size(), 1);
+    int retval = ::poll(pollfds_.data(), pollfds_.size(), 1);
     return retval;
 }
 
@@ -342,10 +350,6 @@ int MotorManager::poll() {
 int MotorManager::multipoll(uint32_t timeout_ns) {
     struct timespec timeout = {};
     Timer t(timeout_ns);
-    for (uint8_t i=0; i<motors_.size(); i++) {
-        pollfds_.at(i).fd = motors_[i]->fd();
-        pollfds_.at(i).events = POLLIN;
-    }
 
     int retval;
     do {
@@ -353,13 +357,13 @@ int MotorManager::multipoll(uint32_t timeout_ns) {
         if (timeout.tv_nsec == 0) {
             return -ETIMEDOUT;
         }
-        retval = ::ppoll(pollfds_.data(), motors_.size(), &timeout, nullptr);
+        retval = ::ppoll(pollfds_.data(), pollfds_.size(), &timeout, nullptr);
         if (retval == 0) {
             return -ETIMEDOUT;
         } else if (retval < 0) {
             return retval;
         } 
-    } while (static_cast<uint8_t>(retval) < motors_.size());
+    } while (static_cast<uint8_t>(retval) < pollfds_.size());
     return retval;
 }
 

--- a/src/motor/motor_manager.cpp
+++ b/src/motor/motor_manager.cpp
@@ -340,8 +340,8 @@ bool MotorManager::deserialize_saved_commands(char *data) {
    return false;
 }
 
-int MotorManager::poll() {
-    int retval = ::poll(pollfds_.data(), pollfds_.size(), 1);
+int MotorManager::poll(uint32_t timeout_ms) {
+    int retval = ::poll(pollfds_.data(), pollfds_.size(), timeout_ms);
     return retval;
 }
 

--- a/src/motor/motor_manager.cpp
+++ b/src/motor/motor_manager.cpp
@@ -335,13 +335,12 @@ bool MotorManager::deserialize_saved_commands(char *data) {
 }
 
 int MotorManager::poll() {
-    auto pollfds = new pollfd[motors_.size()];
+    pollfd pollfds[motors_.size()];
     for (uint8_t i=0; i<motors_.size(); i++) {
         pollfds[i].fd = motors_[i]->fd();
         pollfds[i].events = POLLIN;
     }
     int retval = ::poll(pollfds, motors_.size(), 1);
-    delete [] pollfds;
     return retval;
 }
 


### PR DESCRIPTION
This PR prevents the construction and destruction of `pollfd` objects every time the `poll` or `multipoll` functions are called. We can initialize the array once when the motor list is set and reuse it across function calls.