### PR TITLE
Pull out USB motor into a separate class

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,10 @@
+# Use the Google style in this project.
+BasedOnStyle: Google
+
+# Some folks prefer to write "int& foo" while others prefer "int &foo".  The
+# Google Style Guide only asks for consistency within a project, we chose
+# "int& foo" for this project:
+DerivePointerAlignment: false
+PointerAlignment: Left
+ColumnLimit: 100
+IndentWidth: 4

--- a/include/motor.h
+++ b/include/motor.h
@@ -220,52 +220,19 @@ inline double& operator<<(double& d, TextAPIItem const& item) {
     return d;
 }
 
-static int get_lock_pid(int fd, pid_t *pid) {
-    struct flock lock;
-    lock.l_type = F_WRLCK;
-    lock.l_start = 0;
-    lock.l_whence = 0;
-    lock.l_len = 0;
-    int err = ::fcntl(fd, F_GETLK, &lock);
-    if (err == 0) {
-        *pid = lock.l_pid;
-    }
-    return err;
-}
-
 class Motor : public MotorDescription {
  public:
     enum MessagesCheck {NONE, MAJOR, MINOR};
-    Motor() {}
+    Motor() = default;
     Motor(std::string dev_path);
     virtual ~Motor();
-    virtual ssize_t read() { return ::read(fd_, &status_, sizeof(status_)); }
-    virtual ssize_t write() { if (!no_write_) {
-        return ::write(fd_, &command_, sizeof(command_));
-     } else {
-        std::cerr << "motor " + name() + " locked";
-        pid_t pid;
-        int err = get_lock_pid(fd_, &pid);
-        if (err == 0) {
-            std::cerr << " by process: " << pid;
-        }
-        std::cerr << ", not writeable" << std::endl;;
-        return -1;
-     } }
-    virtual int lock() { 
-        ::lseek(fd_, 0, SEEK_SET);
-        int err = lockf(fd_, F_TLOCK, 0); 
-        if (err) {
-            std::cerr << "error locking " + name();
-            pid_t pid;
-            int err2 = get_lock_pid(fd_, &pid);
-            if (err2 == 0) {
-                std::cerr << ", already locked by process: " << pid;
-            }
-            std::cerr << std::endl;
-        }
-        return err;
-    }
+    virtual ssize_t read() = 0;
+    virtual ssize_t write() = 0;
+    
+    /// @brief If supported by the inherited motor class, lock it so that only one process can write to it at a time.
+    /// @return 0 on success, -1 on failure
+    virtual int lock() { return 0; }
+
     virtual int set_nonblock() { nonblock_ = true;
         return fcntl(fd_, F_SETFL, fd_flags_ | O_NONBLOCK); }
     virtual int clear_nonblock() { nonblock_ = false;
@@ -465,7 +432,7 @@ class UserSpaceMotor : public Motor {
         config_ = operator[]("config").get();
     }
     virtual ~UserSpaceMotor() override;
-    virtual int lock() override {
+    int lock() final {
         std::cerr << "Locking not supported on user space motor" << std::endl;
         errno = 1;
         return -1;

--- a/include/motor.h
+++ b/include/motor.h
@@ -270,7 +270,7 @@ class Motor : public MotorDescription {
     TextFile* motor_text() { return motor_txt_.get(); }
     std::string get_fast_log();
     virtual std::vector<std::string> get_api_options();
-    uint32_t get_cpu_frequency() { return std::stoi((*this)["cpu_frequency"].get()); }
+    virtual uint32_t get_cpu_frequency() { return std::stoi((*this)["cpu_frequency"].get()); }
  protected:
     /// @brief Open the communication channel with the motor controller.
     /// @return -1 on failure, or non-zero value on success.

--- a/include/motor_ip.h
+++ b/include/motor_ip.h
@@ -63,6 +63,11 @@ class MotorIP : public Motor {
     uint32_t port() const { return std::atol(realtime_communication_.port_.c_str()); }
     virtual ssize_t read() override;
     virtual ssize_t write() override;
+    virtual int lock() final {
+        std::cerr << "Locking not supported on IP motor" << std::endl;
+        errno = 1;
+        return -1;
+    }
 
  private:
     UDPFile realtime_communication_;

--- a/include/motor_usb.h
+++ b/include/motor_usb.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "motor.h"
+
+namespace obot {
+
+class MotorUSB : public Motor {
+   public:
+    MotorUSB() = default;
+
+    MotorUSB(std::string dev_path);
+
+    virtual ~MotorUSB();
+
+    ssize_t read() final;
+
+    ssize_t write() final;
+
+    int lock() final;
+};
+
+}  // namespace obot

--- a/include/motor_usb.h
+++ b/include/motor_usb.h
@@ -17,6 +17,21 @@ class MotorUSB : public Motor {
     ssize_t write() final;
 
     int lock() final;
+
+    int set_nonblock() final;
+
+    int clear_nonblock() final;
+
+    ssize_t aread() final;
+
+   protected:
+    /// @brief Open the file descriptor
+    /// @return file descriptor on success, -1 on failure
+    int open() final;
+
+    /// @brief Close the file descriptor
+    /// @return 0 on success, -1 on failure
+    int close() final;
 };
 
 }  // namespace obot

--- a/include/motor_util_fun.h
+++ b/include/motor_util_fun.h
@@ -26,8 +26,8 @@ class MotorDescription {
         auto pos = std::min(s.find(" "), s.find("-g"));
         return s.substr(0,pos);
     }
-    virtual void set_timeout_ms(int timeout_ms) {};
-    virtual int get_timeout_ms() const { return 0; };
+    virtual void set_timeout_ms(int timeout_ms) {}
+    virtual int get_timeout_ms() const { return 0; }
  protected:
     std::string name_, serial_number_, base_path_, dev_path_, version_;
     std::string board_name_, board_rev_, board_num_, messages_version_, config_;

--- a/src/motor/CMakeLists.txt
+++ b/src/motor/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(motor_manager motor_manager.cpp motor.cpp motor_ip.cpp realtime_thread.cpp motor_thread.cpp motor_app.cpp)
+add_library(motor_manager motor_manager.cpp motor.cpp motor_ip.cpp motor_usb.cpp realtime_thread.cpp motor_thread.cpp motor_app.cpp)
 target_link_libraries(motor_manager udev pthread cli11)
 target_include_directories(motor_manager PUBLIC ${CMAKE_SOURCE_DIR}/include)
 set(MOTOR_MANAGER_PUBLIC_HEADERS 
@@ -6,6 +6,7 @@ set(MOTOR_MANAGER_PUBLIC_HEADERS
     ${CMAKE_SOURCE_DIR}/include/motor_messages.h
     ${CMAKE_SOURCE_DIR}/include/motor.h
     ${CMAKE_SOURCE_DIR}/include/motor_ip.h
+    ${CMAKE_SOURCE_DIR}/include/motor_usb.h
     ${CMAKE_SOURCE_DIR}/include/realtime_thread.h
     ${CMAKE_SOURCE_DIR}/include/motor_thread.h
     ${CMAKE_SOURCE_DIR}/include/motor_app.h
@@ -50,12 +51,14 @@ if(INSTALL_MOTOR_EMBEDDED)
     configure_file(${CMAKE_SOURCE_DIR}/include/motor_manager.h motor_manager_embedded/motor_manager.h COPYONLY)
     configure_file(${CMAKE_SOURCE_DIR}/include/motor.h motor_manager_embedded/motor.h COPYONLY)
     configure_file(${CMAKE_SOURCE_DIR}/include/motor_ip.h motor_manager_embedded/motor_ip.h COPYONLY)
+    configure_file(${CMAKE_SOURCE_DIR}/include/motor_usb.h motor_manager_embedded/motor_usb.h COPYONLY)
     configure_file(${CMAKE_SOURCE_DIR}/include/motor_util_fun.h motor_manager_embedded/motor_util_fun.h COPYONLY)
     configure_file(${CMAKE_SOURCE_DIR}/include/motor_messages.h motor_manager_embedded/motor_messages.h COPYONLY)
     configure_file(${CMAKE_SOURCE_DIR}/include/motor_messages/motor_messages.h motor_manager_embedded/motor_messages/motor_messages.h COPYONLY)
     configure_file(motor_manager.cpp motor_manager_embedded/motor_manager.cpp COPYONLY)
     configure_file(motor.cpp motor_manager_embedded/motor.cpp COPYONLY)
     configure_file(motor_ip.cpp motor_manager_embedded/motor_ip.cpp COPYONLY)
+    configure_file(motor_usb.cpp motor_manager_embedded/motor_usb.cpp COPYONLY)
     configure_file(motor_manager_embedded/CMakeLists.txt motor_manager_embedded/CMakeLists.txt COPYONLY)
     configure_file(motor_manager_embedded/BUILD motor_manager_embedded/BUILD COPYONLY)
     add_subdirectory(${CMAKE_CURRENT_BINARY_DIR}/motor_manager_embedded ${CMAKE_CURRENT_BINARY_DIR}/motor_manager_embedded_build)

--- a/src/motor/motor.cpp
+++ b/src/motor/motor.cpp
@@ -2,47 +2,6 @@
 
 namespace obot {
 
-static std::string udev_device_check_and_get_sysattr_value(struct udev_device *dev, const char * name) {
-    const char *value = udev_device_get_sysattr_value(dev, name);
-    if (value != nullptr) {
-        return value;
-    }
-    return "";
-}
-
-Motor::Motor(std::string dev_path) { 
-    dev_path_ = dev_path; 
-    struct udev *udev = udev_new();
-    struct udev_device *dev = udev_device_new_from_subsystem_sysname(udev, "usbmisc", basename(const_cast<char *>(dev_path.c_str())));
-    if (!dev) {
-        throw std::runtime_error("No device: " + dev_path);
-    }
-    name_ = udev_device_check_and_get_sysattr_value(dev, "device/interface");
-
-    std::string text_api_path = udev_device_get_syspath(dev);
-    attr_path_ = text_api_path + "/device";
-    motor_txt_ = std::move(std::unique_ptr<SysfsFile>(new SysfsFile(text_api_path + "/device/text_api")));
-
-    struct udev_device *dev_parent = udev_device_get_parent_with_subsystem_devtype(
-            dev,
-            "usb",
-            "usb_device");
-    serial_number_ = udev_device_check_and_get_sysattr_value(dev_parent, "serial"); 
-    base_path_ = basename(const_cast<char *>(udev_device_get_syspath(dev_parent)));
-    version_ = udev_device_check_and_get_sysattr_value(dev_parent, "configuration");
-    devnum_ = std::stoi(udev_device_check_and_get_sysattr_value(dev_parent, "devnum"));
-
-    udev_device_unref(dev);
-    udev_unref(udev);
-    open();
-
-    messages_version_ = operator[]("messages_version").get();
-    board_name_ = operator[]("board_name").get();
-    board_rev_ = operator[]("board_rev").get();
-    board_num_ = operator[]("board_num").get();
-    config_ = operator[]("config").get();
-}
-
 Motor::~Motor() { close(); }
 
 std::string Motor::get_fast_log() {

--- a/src/motor/motor.cpp
+++ b/src/motor/motor.cpp
@@ -2,8 +2,6 @@
 
 namespace obot {
 
-Motor::~Motor() { close(); }
-
 std::string Motor::get_fast_log() {
     std::string s_read, s_out;
     s_out += "timestamp, position, iq_des, iq_meas_filt, ia, ib, ic, va, vb, vc, vbus\n";

--- a/src/motor/motor_ip.cpp
+++ b/src/motor/motor_ip.cpp
@@ -146,4 +146,8 @@ ssize_t MotorIP::write() {
     return realtime_communication_.write((char *) &command_, sizeof(command_));
 }
 
+ssize_t MotorIP::aread() {
+  throw std::runtime_error("Asynchronous read not implemented for MotorIP class.");
+} 
+
 }; // namespace obot

--- a/src/motor/motor_manager.cpp
+++ b/src/motor/motor_manager.cpp
@@ -1,6 +1,7 @@
 #include "motor_manager.h"
 #include "motor.h"
 #include "motor_ip.h"
+#include "motor_usb.h"
 
 #include <libudev.h>
 
@@ -74,7 +75,7 @@ std::vector<std::shared_ptr<Motor>> MotorManager::get_connected_motors(bool conn
             if (user_space_driver_ == true) {
                 m.push_back(std::make_shared<UserSpaceMotor>(dev_path));
             } else {
-                m.push_back(std::make_shared<Motor>(dev_path));
+                m.push_back(std::make_shared<MotorUSB>(dev_path));
             }
         } catch (std::runtime_error &e) {
             // There is a runtime_error if the motor is disconnected during this function

--- a/src/motor/motor_manager_embedded/CMakeLists.txt
+++ b/src/motor/motor_manager_embedded/CMakeLists.txt
@@ -1,3 +1,3 @@
-add_library(motor_manager_embedded motor_manager.cpp motor.cpp)
+add_library(motor_manager_embedded motor_manager.cpp motor.cpp motor_usb.cpp)
 #target_include_directories(motor_manager_embedded PUBLIC ${CMAKE_CURRENT_BINARY_DIR}/motor_manager_embedded)
 target_link_libraries(motor_manager_embedded udev)

--- a/src/motor/motor_usb.cpp
+++ b/src/motor/motor_usb.cpp
@@ -1,0 +1,94 @@
+#include "motor_usb.h"
+
+namespace obot {
+
+static std::string udev_device_check_and_get_sysattr_value(struct udev_device* dev,
+                                                           const char* name) {
+    const char* value = udev_device_get_sysattr_value(dev, name);
+    if (value != nullptr) {
+        return value;
+    }
+    return "";
+}
+
+static int get_lock_pid(int fd, pid_t* pid) {
+    struct flock lock;
+    lock.l_type = F_WRLCK;
+    lock.l_start = 0;
+    lock.l_whence = 0;
+    lock.l_len = 0;
+    int err = ::fcntl(fd, F_GETLK, &lock);
+    if (err == 0) {
+        *pid = lock.l_pid;
+    }
+    return err;
+}
+
+MotorUSB::~MotorUSB() { close(); }
+
+MotorUSB::MotorUSB(std::string dev_path) {
+    dev_path_ = dev_path;
+    struct udev* udev = udev_new();
+    struct udev_device* dev = udev_device_new_from_subsystem_sysname(
+        udev, "usbmisc", basename(const_cast<char*>(dev_path.c_str())));
+    if (!dev) {
+        throw std::runtime_error("No device: " + dev_path);
+    }
+    name_ = udev_device_check_and_get_sysattr_value(dev, "device/interface");
+
+    std::string text_api_path = udev_device_get_syspath(dev);
+    attr_path_ = text_api_path + "/device";
+    motor_txt_ =
+        std::move(std::unique_ptr<SysfsFile>(new SysfsFile(text_api_path + "/device/text_api")));
+
+    struct udev_device* dev_parent =
+        udev_device_get_parent_with_subsystem_devtype(dev, "usb", "usb_device");
+    serial_number_ = udev_device_check_and_get_sysattr_value(dev_parent, "serial");
+    base_path_ = basename(const_cast<char*>(udev_device_get_syspath(dev_parent)));
+    version_ = udev_device_check_and_get_sysattr_value(dev_parent, "configuration");
+    devnum_ = std::stoi(udev_device_check_and_get_sysattr_value(dev_parent, "devnum"));
+
+    udev_device_unref(dev);
+    udev_unref(udev);
+    open();
+
+    messages_version_ = operator[]("messages_version").get();
+    board_name_ = operator[]("board_name").get();
+    board_rev_ = operator[]("board_rev").get();
+    board_num_ = operator[]("board_num").get();
+    config_ = operator[]("config").get();
+}
+
+ssize_t MotorUSB::read() { return ::read(fd_, &status_, sizeof(status_)); }
+
+ssize_t MotorUSB::write() {
+    if (!no_write_) {
+        return ::write(fd_, &command_, sizeof(command_));
+    } else {
+        std::cerr << "motor " + name() + " locked";
+        pid_t pid;
+        int err = get_lock_pid(fd_, &pid);
+        if (err == 0) {
+            std::cerr << " by process: " << pid;
+        }
+        std::cerr << ", not writeable" << std::endl;
+        return -1;
+    }
+}
+
+int MotorUSB::lock() {
+    ::lseek(fd_, 0, SEEK_SET);
+    int err = lockf(fd_, F_TLOCK, 0);
+    if (err) {
+        std::cerr << "error locking " + name();
+        pid_t pid;
+        int err2 = get_lock_pid(fd_, &pid);
+        if (err2 == 0) {
+            std::cerr << ", already locked by process: " << pid;
+        }
+        std::cerr << std::endl;
+    }
+    return err;
+}
+
+}  // namespace obot

--- a/src/motor_python.cpp
+++ b/src/motor_python.cpp
@@ -2,6 +2,7 @@
 #include <pybind11/stl.h>
 #include <pybind11/operators.h>
 #include "motor_manager.h"
+#include "motor_usb.h"
 #include <sstream>
 
 namespace py = pybind11;
@@ -188,38 +189,38 @@ PYBIND11_MODULE(motor, m)
         .def("set_command_position_tuning", &MotorManager::set_command_position_tuning)
         .def("set_command_current_tuning", &MotorManager::set_command_current_tuning);
 
-    py::class_<Motor, std::shared_ptr<Motor>>(m, "Motor")
+    py::class_<MotorUSB, std::shared_ptr<MotorUSB>>(m, "MotorUSB")
         .def(py::init<const std::string &>())
-        .def("name", &Motor::name)
-        .def("serial_number", &Motor::serial_number)
-        .def("path", &Motor::base_path)
-        .def("devnum", &Motor::devnum)
-        .def("board_name", &Motor::board_name)
-        .def("board_rev", &Motor::board_rev)
-        .def("board_num", &Motor::board_num)
-        .def("messages_version", &Motor::messages_version)
-        .def("config", &Motor::config)
-        .def("get_fast_log", &Motor::get_fast_log)
-        .def("__repr__", [](const Motor &m){ return "<Motor " + m.name() + ">"; })
-        .def("__getitem__", &Motor::operator[])
-        .def("__setitem__", [](Motor &m, const std::string key, const std::string value)
+        .def("name", &MotorUSB::name)
+        .def("serial_number", &MotorUSB::serial_number)
+        .def("path", &MotorUSB::base_path)
+        .def("devnum", &MotorUSB::devnum)
+        .def("board_name", &MotorUSB::board_name)
+        .def("board_rev", &MotorUSB::board_rev)
+        .def("board_num", &MotorUSB::board_num)
+        .def("messages_version", &MotorUSB::messages_version)
+        .def("config", &MotorUSB::config)
+        .def("get_fast_log", &MotorUSB::get_fast_log)
+        .def("__repr__", [](const MotorUSB &m){ return "<MotorUSB " + m.name() + ">"; })
+        .def("__getitem__", &MotorUSB::operator[])
+        .def("__setitem__", [](MotorUSB &m, const std::string key, const std::string value)
              { m[key].set(value); })
-        .def("get_api_options", &Motor::get_api_options)
-        .def("error_mask", [](Motor &m)
+        .def("get_api_options", &MotorUSB::get_api_options)
+        .def("error_mask", [](MotorUSB &m)
              { 
             MotorError mask;
             mask.all = std::stoul(m["error_mask"].get(), 0, 16);
             return motor_error_dict(mask); })
-        .def("set_error_mask", [](Motor &m, py::dict d){ 
+        .def("set_error_mask", [](MotorUSB &m, py::dict d){ 
             MotorError e = dict_to_motor_error(d);
             std::stringstream s;
             s << std::hex << e.all;
             std::string shex(s.str());
             return m["error_mask"].set(shex); })
-        .def("get_cpu_frequency", &Motor::get_cpu_frequency)
-        .def("set_nonblock", &Motor::set_nonblock)
-        .def("get_timeout_ms", &Motor::get_timeout_ms)
-        .def("set_timeout_ms", &Motor::set_timeout_ms);
+        .def("get_cpu_frequency", &MotorUSB::get_cpu_frequency)
+        .def("set_nonblock", &MotorUSB::set_nonblock)
+        .def("get_timeout_ms", &MotorUSB::get_timeout_ms)
+        .def("set_timeout_ms", &MotorUSB::set_timeout_ms);
 
     py::class_<TextAPIItem>(m, "TextAPIItem")
         .def("__repr__", &TextAPIItem::get)


### PR DESCRIPTION
- Changes `Motor` class into an abstract base class, with all USB-specific implementation code moved to either `MotorUSB` or `UserSpaceMotor`.
- Added a .clang-format file. It should be very similar to the style present already.