### PR TITLE
use rfind for interfaces

### DIFF
--- a/src/motor/motor_eth_l2.cpp
+++ b/src/motor/motor_eth_l2.cpp
@@ -495,7 +495,7 @@ class L2File : public TextFile {
 MotorEthL2::MotorEthL2(std::string address, std::string alias) {
     std::string interface;
     std::string mac;
-    if (int n = address.find("-"); n == std::string::npos) {
+    if (int n = address.rfind("-"); n == std::string::npos) {
         interface = "any";
         mac = address;
     } else {


### PR DESCRIPTION
Allow dashes in interface names
```
./src/motor/motor_util -e intf-abc-00:00:00:00:00:00
intf-abc-00:00:00:00:00:00 exception: ioctl SIOCGIFHWADDR failed for intf-abc: 19: No such device
0 connected motors
```